### PR TITLE
Added sanity check to prevent error with Advanced Custom Fields

### DIFF
--- a/custom-post-type-permalinks.php
+++ b/custom-post-type-permalinks.php
@@ -241,6 +241,9 @@ class Custom_Post_Type_Permalinks {
 
 	public function attachment_link( $link , $postID ) {
 		$post = get_post( $postID );
+		if (!$post->post_parent){
+			return $link;
+		}
 		$post_parent = get_post( $post->post_parent );
 		$permalink = get_option( $post_parent->post_type.'_structure' );
 		$post_type = get_post_type_object( $post_parent->post_type );


### PR DESCRIPTION
Advanced Custom Fields, a very popular plugin for adding custom fields, sometimes uses attachments to store things in the wp_options table. This causes an error now that my sanity check corrects

http://wordpress.org/plugins/advanced-custom-fields/
