### PR TITLE
If the taxonomy rewrite is hierarchical the $termlink is already correct...

### DIFF
--- a/custom-post-type-permalinks.php
+++ b/custom-post-type-permalinks.php
@@ -604,7 +604,9 @@ class Custom_Post_Type_Permalinks {
 		$slug = $str."/".$slug;
 
 		$termlink = str_replace( $wp_home, $wp_home.$slug, $termlink );
-		$termlink = str_replace( $term->slug.'/', $this->get_taxonomy_parents( $term->term_id,$taxonomy->name, false, '/', true ), $termlink );
+		if ( ! $taxonomy->rewrite['hierarchical'] ) {
+			$termlink = str_replace( $term->slug.'/', $this->get_taxonomy_parents( $term->term_id,$taxonomy->name, false, '/', true ), $termlink );
+		}
 		return $termlink;
 	}
 


### PR DESCRIPTION
.... No need to add the parents.

get_term_link already makes a hierarchical link: http://core.trac.wordpress.org/browser/tags/3.6.1/wp-includes/taxonomy.php#L3107
