### PR TITLE
複数のカスタム投稿に対して横断的に使用するタームのリンクが常に単一のものしか取れない問題について修正しました。

### DIFF
--- a/CPTP/Module/Permalink.php
+++ b/CPTP/Module/Permalink.php
@@ -218,9 +218,8 @@ class CPTP_Module_Permalink extends CPTP_Module {
 
 		$wp_home = rtrim( home_url(), '/' );
 
-		global $qobj;
-		if(in_array($qobj->rewrite['slug'], $taxonomy->object_type)){
-			$post_type = $qobj->rewrite['slug'];
+		if(in_array(get_post_type(), $taxonomy->object_type)){
+			$post_type = get_post_type();
 		}
 		else {
 			$post_type = $taxonomy->object_type[0];


### PR DESCRIPTION
表示しているカスタム投稿から、取得するスラッグを調整し、
意図する挙動となるような形としました。

もしよろしければ、マージ頂ければ幸いです。
