### PR TITLE
Get post type name from current pt_object

### DIFF
--- a/CPTP/Util.php
+++ b/CPTP/Util.php
@@ -80,10 +80,10 @@ class CPTP_Util {
 			$structure = $pt_object->cptp_permalink_structure;
 		}
 		else {
-			$structure = get_option( $post_type.'_structure' );
+			$structure = get_option( $pt_object->name.'_structure' );
 		}
 
-		return apply_filters( 'CPTP_'.$post_type.'_structure', $structure );
+		return apply_filters( 'CPTP_'.$pt_object->name.'_structure', $structure );
 	}
 
 


### PR DESCRIPTION
For some reason treating $post_type as string results in a fatal error. Getting the post type name from the current $pt_object variable has the same effect, but does not generate a fatal error.