### PR TITLE
Change priority of filters.

### DIFF
--- a/CPTP/Module/Permalink.php
+++ b/CPTP/Module/Permalink.php
@@ -14,8 +14,8 @@ class CPTP_Module_Permalink extends CPTP_Module {
 
 
 	public function add_hook() {
-		add_filter( 'post_type_link', array( $this, 'post_type_link' ), 10, 4 );
-		add_filter( 'term_link', array( $this, 'term_link' ), 10, 3 );
+		add_filter( 'post_type_link', array( $this, 'post_type_link' ), -10, 4 );
+		add_filter( 'term_link', array( $this, 'term_link' ), -10, 3 );
 		add_filter( 'attachment_link', array( $this, 'attachment_link' ), 20, 2 );
 	}
 


### PR DESCRIPTION
WPML's filters are at:

* post_type_link = 1
* term_link = 10

This patch puts CPTP's filters in a higher priority, so WPML's filters
are triggered after these.

This patch fixes #10 