### PR TITLE
Check if post parent exists

### DIFF
--- a/CPTP/Module/Permalink.php
+++ b/CPTP/Module/Permalink.php
@@ -266,7 +266,7 @@ class CPTP_Module_Permalink extends CPTP_Module {
 		if ( ! $post->post_parent ) {
 			return $link;
 		}
-		$post_parent = get_post( $post->post_parent );
+
 		$post_parent = get_post( $post->post_parent );
 		if ( ! $post_parent) {
 			return $link;

--- a/CPTP/Module/Permalink.php
+++ b/CPTP/Module/Permalink.php
@@ -267,6 +267,10 @@ class CPTP_Module_Permalink extends CPTP_Module {
 			return $link;
 		}
 		$post_parent = get_post( $post->post_parent );
+		$post_parent = get_post( $post->post_parent );
+		if ( ! $post_parent) {
+			return $link;
+		}
 		$permalink   = CPTP_Util::get_permalink_structure( $post_parent->post_type );
 		$post_type   = get_post_type_object( $post_parent->post_type );
 


### PR DESCRIPTION
I ran in to an issue when the `$post->post_parent` had an ID set, but the post didn't actually exist. This PR allows the code to fail correctly.

Thanks for the plugin!