### PR TITLE
Solution for translating CPT slugs with WPML

### DIFF
--- a/CPTP/Module/Permalink.php
+++ b/CPTP/Module/Permalink.php
@@ -80,6 +80,7 @@ class CPTP_Module_Permalink extends CPTP_Module {
 		$permalink = $wp_rewrite->get_extra_permastruct( $post_type );
 
 		$permalink = str_replace( '%post_id%', $post->ID, $permalink );
+		$permalink = str_replace( '%' . $post_type . '_slug%', $pt_object->rewrite['slug'], $permalink );
 
 		// has parent.
 		$parentsDirs = '';

--- a/CPTP/Module/Permalink.php
+++ b/CPTP/Module/Permalink.php
@@ -80,7 +80,6 @@ class CPTP_Module_Permalink extends CPTP_Module {
 		$permalink = $wp_rewrite->get_extra_permastruct( $post_type );
 
 		$permalink = str_replace( '%post_id%', $post->ID, $permalink );
-		$permalink = str_replace( '%' . $post_type . '_slug%', $pt_object->rewrite['slug'], $permalink );
 
 		// has parent.
 		$parentsDirs = '';

--- a/CPTP/Module/Rewrite.php
+++ b/CPTP/Module/Rewrite.php
@@ -61,8 +61,6 @@ class CPTP_Module_Rewrite extends CPTP_Module {
 		$permalink = $args->rewrite['slug'] . $permalink;
 		$permalink = str_replace( '%postname%', '%' . $post_type . '%', $permalink );
 
-		add_rewrite_tag( '%' . $post_type . '_slug%', '(' . $args->rewrite['slug'] . ')', 'post_type=' . $post_type . '&slug=' );
-
 		$taxonomies = CPTP_Util::get_taxonomies( true );
 		foreach ( $taxonomies as $taxonomy => $objects ) :
 			$wp_rewrite->add_rewrite_tag( "%$taxonomy%", '(.+?)', "$taxonomy=" );

--- a/CPTP/Module/Rewrite.php
+++ b/CPTP/Module/Rewrite.php
@@ -50,14 +50,6 @@ class CPTP_Module_Rewrite extends CPTP_Module {
 			$permalink = CPTP_DEFAULT_PERMALINK;
 		}
 
-		// WPML: attempt to translate the CPT slug
-		$args->rewrite['slug'] = apply_filters(
-			'wpml_translate_single_string',
-			$args->rewrite['slug'],
-			'WordPress',
-			'URL slug: ' . $args->rewrite['slug']
-		);
-
 		$permalink = $args->rewrite['slug'] . $permalink;
 		$permalink = str_replace( '%postname%', '%' . $post_type . '%', $permalink );
 

--- a/CPTP/Module/Rewrite.php
+++ b/CPTP/Module/Rewrite.php
@@ -50,7 +50,15 @@ class CPTP_Module_Rewrite extends CPTP_Module {
 			$permalink = CPTP_DEFAULT_PERMALINK;
 		}
 
-		$permalink = '%' . $post_type . '_slug%' . $permalink;
+		// WPML: attempt to translate the CPT slug
+		$args->rewrite['slug'] = apply_filters(
+			'wpml_translate_single_string',
+			$args->rewrite['slug'],
+			'WordPress',
+			'URL slug: ' . $args->rewrite['slug']
+		);
+
+		$permalink = $args->rewrite['slug'] . $permalink;
 		$permalink = str_replace( '%postname%', '%' . $post_type . '%', $permalink );
 
 		add_rewrite_tag( '%' . $post_type . '_slug%', '(' . $args->rewrite['slug'] . ')', 'post_type=' . $post_type . '&slug=' );

--- a/CPTP/Module/Rewrite.php
+++ b/CPTP/Module/Rewrite.php
@@ -53,6 +53,8 @@ class CPTP_Module_Rewrite extends CPTP_Module {
 		$permalink = $args->rewrite['slug'] . $permalink;
 		$permalink = str_replace( '%postname%', '%' . $post_type . '%', $permalink );
 
+		add_rewrite_tag( '%' . $post_type . '_slug%', '(' . $args->rewrite['slug'] . ')', 'post_type=' . $post_type . '&slug=' );
+
 		$taxonomies = CPTP_Util::get_taxonomies( true );
 		foreach ( $taxonomies as $taxonomy => $objects ) :
 			$wp_rewrite->add_rewrite_tag( "%$taxonomy%", '(.+?)', "$taxonomy=" );


### PR DESCRIPTION
This is a solution for translating CPT slugs with WPML.

The problem was reported in WPML forums several times:
https://wpml.org/forums/topic/get-rewrite-slug/
https://wpml.org/forums/topic/custom-post-type-slug-not-translated/

Would you be willing to incorporate such a solution?
I can get you a WPML subscription if you need to test it.