### PR TITLE
wpml compatibility

### DIFF
--- a/CPTP/Module/Rewrite.php
+++ b/CPTP/Module/Rewrite.php
@@ -59,7 +59,7 @@ class CPTP_Module_Rewrite extends CPTP_Module {
 			$permalink = CPTP_DEFAULT_PERMALINK;
 		}
 
-		$permalink = '%' . $post_type . '_slug%' . $permalink;
+		$permalink = $args->rewrite['slug'] . $permalink;
 		$permalink = str_replace( '%postname%', '%' . $post_type . '%', $permalink );
 
 		add_rewrite_tag( '%' . $post_type . '_slug%', '(' . $args->rewrite['slug'] . ')', 'post_type=' . $post_type . '&slug=' );


### PR DESCRIPTION
Slugs generated by WPML doesn't get translated properply, this hotfix seems to resolve this issue. Tested and working in all languages.