### PR TITLE
Add filter to support WPML's CPT slug translation

### DIFF
--- a/CPTP/Module/Permalink.php
+++ b/CPTP/Module/Permalink.php
@@ -37,6 +37,13 @@ class CPTP_Module_Permalink extends CPTP_Module {
 			apply_filters( 'cptp_attachment_link_priority', 20 ),
 			2
 		);
+
+		add_filter(
+			'wpml_st_post_type_link_filter_original_slug',
+			array( $this, 'replace_post_slug_with_placeholder' ),
+			10,
+			3
+		);
 	}
 
 
@@ -90,7 +97,7 @@ class CPTP_Module_Permalink extends CPTP_Module {
 		$permalink = $wp_rewrite->get_extra_permastruct( $post_type );
 
 		$permalink = str_replace( '%post_id%', $post->ID, $permalink );
-		$permalink = str_replace( '%' . $post_type . '_slug%', $pt_object->rewrite['slug'], $permalink );
+		$permalink = str_replace( CPTP_Module_Rewrite::get_slug_placeholder( $post_type ), $pt_object->rewrite['slug'], $permalink );
 
 		// has parent.
 		$parentsDirs = '';
@@ -387,5 +394,19 @@ class CPTP_Module_Permalink extends CPTP_Module {
 		}
 
 		return $termlink;
+	}
+
+	/**
+	 * This filter is needed for WPML's compatibility. It will return
+	 * the slug placeholder instead of the original CPT slug.
+	 *
+	 * @param string  $original_slug The original CPT slug.
+	 * @param string  $post_link     The post link.
+	 * @param WP_Post $post          The post.
+	 *
+	 * @return string
+	 */
+	public function replace_post_slug_with_placeholder( $original_slug, $post_link, $post ) {
+		return CPTP_Module_Rewrite::get_slug_placeholder( $post->post_type );
 	}
 }

--- a/CPTP/Module/Rewrite.php
+++ b/CPTP/Module/Rewrite.php
@@ -59,10 +59,11 @@ class CPTP_Module_Rewrite extends CPTP_Module {
 			$permalink = CPTP_DEFAULT_PERMALINK;
 		}
 
-		$permalink = '%' . $post_type . '_slug%' . $permalink;
-		$permalink = str_replace( '%postname%', '%' . $post_type . '%', $permalink );
+		$slug_placeholder = self::get_slug_placeholder( $post_type );
+		$permalink        = $slug_placeholder . $permalink;
+		$permalink        = str_replace( '%postname%', '%' . $post_type . '%', $permalink );
 
-		add_rewrite_tag( '%' . $post_type . '_slug%', '(' . $args->rewrite['slug'] . ')', 'post_type=' . $post_type . '&slug=' );
+		add_rewrite_tag( $slug_placeholder, '(' . $args->rewrite['slug'] . ')', 'post_type=' . $post_type . '&slug=' );
 
 		$taxonomies = CPTP_Util::get_taxonomies( true );
 		foreach ( $taxonomies as $taxonomy => $objects ) :
@@ -279,5 +280,16 @@ class CPTP_Module_Rewrite extends CPTP_Module {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Returns the slug placeholder user in the permalink structure.
+	 *
+	 * @param string $post_type The post type.
+	 *
+	 * @return string
+	 */
+	public static function get_slug_placeholder( $post_type ) {
+		return '%' . $post_type . '_slug%';
 	}
 }

--- a/tests/test-cptp-module-permalink.php
+++ b/tests/test-cptp-module-permalink.php
@@ -412,6 +412,17 @@ class CPTP_Module_Permalink_Test extends WP_UnitTestCase {
 		$this->assertTrue( is_attachment() );
 	}
 
+	/**
+	 * @test
+	 * @group permalink
+	 */
+	public function test_wpml_st_post_type_link_filter_original_slug() {
+		$post = (object) [ 'post_type' => 'some-type' ];
 
+		$this->assertEquals(
+			CPTP_Module_Rewrite::get_slug_placeholder( $post->post_type ),
+			apply_filters( 'wpml_st_post_type_link_filter_original_slug', 'ignored', 'ignored', $post )
+		);
+	}
 }
 


### PR DESCRIPTION
Hi,

Eventually we managed to take over this issue which is affecting a significant number of WPML users:

https://wpml.org/forums/topic/custom-post-type-ui-slug-translations
https://wpml.org/forums/topic/slug-for-custom-posy-type
https://wpml.org/forums/topic/slug-not-translating
https://wpml.org/forums/topic/slug-translations-2
https://wpml.org/forums/topic/slugs-not-translating

Initially we suggested a quick fix (https://github.com/torounit/custom-post-type-permalinks/pull/91) but it was not robust enough.

We are making adjustments on WPML to improve the compatibility but we won't be able to fix everything on our side. Indeed, we are using the permalink structure to translate the CPT slug before to generate permalinks in secondary languages.

So we will create a new filter hook in WPML's code (see below):

```php
/**
 * This hook allows to filter the slug we want to search and replace
 * in the permalink structure. This is required for 3rd party
 * plugins replacing the original slug with a placeholder.
 *
 * @since 3.1.0
 *
 * @param string  $slug_this The original slug.
 * @param string  $post_link The initial link.
 * @param WP_Post $post      The post.
 * @param bool    $leavename Whether to keep the post name.
 * @param bool    $sample    Is it a sample permalink.
 */
$slug_this = apply_filters( 'wpml_st_post_type_link_filter_original_slug', $slug_this, $post_link, $post, $leavename, $sample );
```

Here, we will add a filter on this hook that will return the slug placehoder used in the permalink structure.

_Example:_ `book` CPT will return `%book_slug%`.

WPML references: wpmlcore-7090 & comp-3178.