### PR TITLE
PHP8.2 Compatability

### DIFF
--- a/CPTP/Util.php
+++ b/CPTP/Util.php
@@ -57,8 +57,8 @@ class CPTP_Util {
 		 *
 		 * @param bool $support support CPTP.
 		 */
-		$support = apply_filters( "CPTP_is_rewrite_supported_by_${post_type}", $support );
-		$support = apply_filters( "cptp_is_rewrite_supported_by_${post_type}", $support );
+		$support = apply_filters( "CPTP_is_rewrite_supported_by_{$post_type}", $support );
+		$support = apply_filters( "cptp_is_rewrite_supported_by_{$post_type}", $support );
 
 		/**
 		 * Filters support CPTP for custom post type.


### PR DESCRIPTION
Using `${var}` is Deprecated in PHP 8.2 and throws errors. This makes it compatible and has no errors showing.