### PR TITLE
fix: fix PHP notices

### DIFF
--- a/CPTP/Module/Permalink.php
+++ b/CPTP/Module/Permalink.php
@@ -403,6 +403,10 @@ class CPTP_Module_Permalink extends CPTP_Module {
 			return $termlink;
 		}
 
+		if ( ! isset( $post_type_obj->rewrite['slug'] ) || ! isset( $post_type_obj->rewrite['with_front'] ) ) {
+			return $termlink;
+		}
+
 		$slug       = $post_type_obj->rewrite['slug'];
 		$with_front = $post_type_obj->rewrite['with_front'];
 


### PR DESCRIPTION
失礼いたします。

`get_term_link()` に `post_tag` を渡すと以下のラインでNoticeが出力されるようです。

e.g. `get_term_link( 11, 'post_tag' );`

https://github.com/torounit/custom-post-type-permalinks/blob/bb0a66cae01a61db13a1de1cc1679d63ac35f367/CPTP/Module/Permalink.php#L406-L407

```
[09-Dec-2023 08:10:17 UTC] PHP Notice:  Trying to access array offset on value of type bool in /xxxxxxxxx/wp-content/plugins/custom-post-type-permalinks/CPTP/Module/Permalink.php on line 407
[09-Dec-2023 08:10:17 UTC] PHP Notice:  Trying to access array offset on value of type bool in /xxxxxxxxx/wp-content/plugins/custom-post-type-permalinks/CPTP/Module/Permalink.php on line 406
```

このPRはこちらのNoticeを解消するものです。

一度ご確認いただけないでしょうか。
よろしくお願いいたします。
