### PR TITLE
Ensure that the taxonomy's rewrite property is not false

### DIFF
--- a/CPTP/Module/Permalink.php
+++ b/CPTP/Module/Permalink.php
@@ -418,7 +418,7 @@ class CPTP_Module_Permalink extends CPTP_Module {
 			$termlink = str_replace( $wp_home, $wp_home . '/' . $slug, $termlink );
 		}
 
-		if ( ! $taxonomy->rewrite['hierarchical'] ) {
+		if ( $axonomy->rewrite !== false && ! $taxonomy->rewrite['hierarchical'] ) {
 			$termlink = str_replace( $term->slug . '/', CPTP_Util::get_taxonomy_parents_slug( $term->term_id, $taxonomy->name, '/', true ), $termlink );
 		}
 

--- a/CPTP/Module/Permalink.php
+++ b/CPTP/Module/Permalink.php
@@ -418,7 +418,7 @@ class CPTP_Module_Permalink extends CPTP_Module {
 			$termlink = str_replace( $wp_home, $wp_home . '/' . $slug, $termlink );
 		}
 
-		if ( $axonomy->rewrite !== false && ! $taxonomy->rewrite['hierarchical'] ) {
+		if ( $taxonomy->rewrite !== false && ! $taxonomy->rewrite['hierarchical'] ) {
 			$termlink = str_replace( $term->slug . '/', CPTP_Util::get_taxonomy_parents_slug( $term->term_id, $taxonomy->name, '/', true ), $termlink );
 		}
 


### PR DESCRIPTION
If a taxonomy's rewrite property is set to `false`,  in PHP 8 a warning is emitted:

```
Warning: Trying to access array offset on value of type bool in /var/www/html/http/htdocs/content/plugins/custom-post-type-permalinks/CPTP/Module/Permalink.php on line 421
```