### PR TITLE
Update references from master to main branch

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -5,7 +5,7 @@ on:
     paths-ignore:
       - "**.md"
   push:
-    branches: [master]
+    branches: [main]
     tags: ["*"]
     paths-ignore:
       - "**.md"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,12 +11,12 @@
 ## Making Changes
 
 * Create a topic branch from where you want to base your work.
-  * This is usually the master branch.
+  * This is usually the main branch.
   * Only target release branches if you are certain your fix must be on that
     branch.
-  * To quickly create a topic branch based on master; `git checkout -b
-    fix/master/my_contribution master`. Please avoid working directly on the
-    `master` branch.
+  * To quickly create a topic branch based on main; `git checkout -b
+    fix/main/my_contribution main`. Please avoid working directly on the
+    `main` branch.
 * Make commits of logical units.
 * Check for unnecessary whitespace with `git diff --check` before committing.
 * Make sure your commit messages are in the proper format.

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ Edit the permalink of custom post type.
 <!-- only:github/ -->
 
 [![Latest Stable Version](https://img.shields.io/wordpress/plugin/v/custom-post-type-permalinks?style=for-the-badge)](https://wordpress.org/plugins/custom-post-type-permalinks/)
-[![License](https://img.shields.io/github/license/torounit/custom-post-type-permalinks?style=for-the-badge)](https://github.com/torounit/custom-post-type-permalinks/blob/master/LICENSE)
+[![License](https://img.shields.io/github/license/torounit/custom-post-type-permalinks?style=for-the-badge)](https://github.com/torounit/custom-post-type-permalinks/blob/main/LICENSE)
 [![Downloads](https://img.shields.io/wordpress/plugin/dt/custom-post-type-permalinks.svg?style=for-the-badge)](https://wordpress.org/plugins/custom-post-type-permalinks/)
 [![Tested up](https://img.shields.io/wordpress/v/custom-post-type-permalinks.svg?style=for-the-badge)](https://wordpress.org/plugins/custom-post-type-permalinks/)
 [![wp.org rating](https://img.shields.io/wordpress/plugin/r/custom-post-type-permalinks.svg?style=for-the-badge)](https://wordpress.org/plugins/custom-post-type-permalinks/)
-[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/torounit/custom-post-type-permalinks/test-and-release.yml?branch=master&style=for-the-badge)](https://github.com/torounit/custom-post-type-permalinks/actions)
+[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/torounit/custom-post-type-permalinks/test-and-release.yml?branch=main&style=for-the-badge)](https://github.com/torounit/custom-post-type-permalinks/actions)
 
 [![](https://ps.w.org/custom-post-type-permalinks/assets/banner-1544x500.png?rev=1044335)](https://wordpress.org/plugins/custom-post-type-permalinks/)
 


### PR DESCRIPTION
## Summary
- CI workflow の push トリガーを `master` → `main` に変更
- README.md のバッジ URL を `master` → `main` に更新
- CONTRIBUTING.md のブランチ参照を `master` → `main` に更新

## Test plan
- [ ] CI が `main` への push で正常にトリガーされることを確認
- [ ] README のバッジが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)